### PR TITLE
Queue, exchange, and consume options configurable through MessageBroker ctor param

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "dosomething/messagebroker-phplib",
     "type": "library",
-    "version": "0.1.9",
+    "version": "0.1.10",
     "description": "A library of functionality shared between the components that make up the DoSomething.org Message Broker system.",
     "keywords": ["rabbitmq", "message broker php library"],
     "homepage": "https://github.com/DoSomething/messagebroker-phplib",


### PR DESCRIPTION
@DeeZone here's a thought for how queue, exchange, and consume options can be set. They'd no longer be hardcoded in the library, but controlled by the producers and consumers. I imagine the producers and consumers would have to do something like:

```
$config = array(
  // Routing key
  'routingKey' => 'mailchimp-unsubscribe',

  // Consume options
  'consume' => array(
    'consumer_tag' => '',
    'no_local' => FALSE,
    'no_ack' => FALSE,
    'exclusive' => FALSE,
    'nowait' => FALSE,
  ),

  // Exchange options
  'exchange' => array(
    'name' => 'direct_mailchimp_webhooks',
    'type' => 'direct',
    'passive' => FALSE,
    'durable' => TRUE,
    'auto_delete' => FALSE,
  ),

  // Queue options
  'queue' => array(
    'name' => 'mailchimp-unsubscribe-queue',
    'passive' => FALSE,
    'durable' => TRUE,
    'exclusive' => FALSE,
    'auto_delete' => FALSE,
  ),
);

$mb = new MessageBroker($credentials, $config);
```

Those options can alternatively be pulled from the mb-config.inc.

Also, if this PR goes through, it'll bump the version up to 0.1.10.
